### PR TITLE
Typo's

### DIFF
--- a/ckeditor-4.3.0/plugins/pwlink/plugin.js
+++ b/ckeditor-4.3.0/plugins/pwlink/plugin.js
@@ -67,8 +67,8 @@
 		var $textarea = $('textarea#' + editor.name); // get textarea of this instance
 		var $langWrapper = $textarea.closest('.LanguageSupport');
 		if($langWrapper.length) lang_id = "&lang=" + $langWrapper.data("language");
-
-		var modalUri = config.urls.admin + 'page/link/?id=' + page_id + '&modal=1' + lang_id;
+		// typo's fixed
+		var modalUrl = config.urls.admin + 'page/link/?id=' + pageID + '&modal=1' + lang_id;
 		var $iframe = $('<iframe id="pwlink_iframe" frameborder="0" src="' + modalUrl + '"></iframe>');
 		var selection = editor.getSelection(true);
 		var selectionElement = selection.getSelectedElement();


### PR DESCRIPTION
Think there were 2 typo's on line 71  which throwed an error on the console & prevented the modal popup.

modalUrl was called modalUri & pageID was called page_id
