### PR TITLE
Replace obsoleted escape() with encodeURIComponent()

### DIFF
--- a/ckeditor-4.3.2/plugins/pwimage/plugin.js
+++ b/ckeditor-4.3.2/plugins/pwimage/plugin.js
@@ -113,8 +113,8 @@
 		if(imgWidth) queryString += "&width=" + imgWidth; 
 		if(imgHeight) queryString += "&height=" + imgHeight; 
 		if(imgClass && imgClass.length) queryString += "&class=" + imgClass; 
-		if(imgDescription && imgDescription.length) queryString += "&description=" + escape(imgDescription);
-		if(imgLink && imgLink.length) queryString += "&link=" + escape(imgLink);
+		if(imgDescription && imgDescription.length) queryString += "&description=" + encodeURI(imgDescription);
+		if(imgLink && imgLink.length) queryString += "&link=" + encodeURI(imgLink);
 		queryString += "&winwidth=" + windowWidth; 
 
 		// create iframe dialog box

--- a/ckeditor-4.3.2/plugins/pwimage/plugin.js
+++ b/ckeditor-4.3.2/plugins/pwimage/plugin.js
@@ -113,8 +113,8 @@
 		if(imgWidth) queryString += "&width=" + imgWidth; 
 		if(imgHeight) queryString += "&height=" + imgHeight; 
 		if(imgClass && imgClass.length) queryString += "&class=" + imgClass; 
-		if(imgDescription && imgDescription.length) queryString += "&description=" + encodeURI(imgDescription);
-		if(imgLink && imgLink.length) queryString += "&link=" + encodeURI(imgLink);
+		if(imgDescription && imgDescription.length) queryString += "&description=" + encodeURIComponent(imgDescription);
+		if(imgLink && imgLink.length) queryString += "&link=" + encodeURIComponent(imgLink);
 		queryString += "&winwidth=" + windowWidth; 
 
 		// create iframe dialog box


### PR DESCRIPTION
This fixes various UTF-8 issues, mostly related to description field: escape() doesn't handle UTF-8 (or non-ASCII characters to be precise) properly, so it gets encoded incorrectly. As a result ProcessPageEditImageSelect.module will in some cases (such as when umlauts are present) discard whole description text.

Since escape() has been obsoleted in JavaScript 1.5+ (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Functions#escape_and_unescape_functions(Obsoleted_above_JavaScript_1.5) for details) it makes sense to remove it from link encoding too, though issues there should be pretty rare.
