### PR TITLE
Fix for the broken language support when linking

### DIFF
--- a/ckeditor-4.4.2/plugins/pwlink/plugin.js
+++ b/ckeditor-4.4.2/plugins/pwlink/plugin.js
@@ -64,7 +64,7 @@
 
 		// language support
 		var langID = '';
-		var $textarea = $('.InputfieldCKEditorLoaded#' + editor.name); // get textarea of this instance
+		var $textarea = $('#' + editor.name); // get textarea of this instance
 		var $langWrapper = $textarea.closest('.LanguageSupport');
 		if($langWrapper.length) langID = "&lang=" + $langWrapper.data("language");
 

--- a/ckeditor-4.4.2/plugins/pwlink/plugin.js
+++ b/ckeditor-4.4.2/plugins/pwlink/plugin.js
@@ -64,7 +64,7 @@
 
 		// language support
 		var langID = '';
-		var $textarea = $('textarea#' + editor.name); // get textarea of this instance
+		var $textarea = $('.InputfieldCKEditorLoaded#' + editor.name); // get textarea of this instance
 		var $langWrapper = $textarea.closest('.LanguageSupport');
 		if($langWrapper.length) langID = "&lang=" + $langWrapper.data("language");
 


### PR DESCRIPTION
Since CKEditor instances no longer have textareas, this selector fixes the broken language support when linking to page.
